### PR TITLE
Fix error due to IndexOutOfRange for row while calculating concentrations from weight

### DIFF
--- a/hb_main.pas
+++ b/hb_main.pas
@@ -2860,8 +2860,6 @@ if RadioButton13.Checked then
 
       end;
 
-      StringGrid2.RowCount := i+2 ;
-
       StringGrid2.Cells[NAME_IDX,i+1] := (name_array[i][0]);
       StringGrid2.Cells[FORMULA_IDX,i+1] := (name_array[i][1]);
       StringGrid2.Cells[COST_IDX,i+1] := (FloattoStr(


### PR DESCRIPTION
`StringGrid2.RowCount` already gets properly set to `arraysize + 1` on line 1810, and `arraySize` is equal to the `Count` of the Substances Used Grid/list (`Form2.ListBox2`). Attempting to increment like this introduces a logical error.

(Still unfamiliar with this repo/codebase and don't know this language so my terminology used to describe aspects of the code might be entirely incorrect. Sorry!)